### PR TITLE
Toggle track and segment looping

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -5,7 +5,10 @@
       <div v-show="!smallSize" class="vert">
         <div class="playpause seconds" @click="skipToBeginning" ref="skipBackButton"></div>
         <div class="playpause" @click="togglePlay" ref="playpause"></div>
-        <div class="playpause seconds" @click="toggleLooping" v-bind:class="{'looping': this.looping}" ref="loopButton"></div>
+        <div class="playpause seconds" @click="toggleLooping"
+          v-bind:class="{'looping': this.looping}"
+          ref="loopButton">
+        </div>
       </div>
       <div class="vert wide">
         <div class="waveform">

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -3,8 +3,8 @@
     <div class="player-title">{{ displayTitle }}</div>
     <div class="horiz">
       <div v-show="!smallSize" class="vert">
-        <div class="playpause" @click="togglePlay" ref="playpause">
-        </div>
+        <div class="playpause" @click="togglePlay" ref="playpause"></div>
+        <div class="playpause seconds" @click="toggleLooping" ref="loopButton"></div>
       </div>
       <div class="vert wide">
         <div class="waveform">
@@ -108,6 +108,7 @@ export default defineComponent({
       duration: 0,
       currentTime: 0,
       playing: false,
+      looping: false,
       button: undefined as HTMLSpanElement | undefined,
       button1: undefined as HTMLSpanElement | undefined,
 
@@ -221,6 +222,18 @@ export default defineComponent({
 
       if (this.isCurrent()) {
         this.audio.currentTime = time;
+      }
+    },
+    toggleLooping() {
+      this.looping = ! this.looping;
+      this.audio.loop = this.looping;
+    
+      const button = this.$refs.loopButton;
+    
+      if (this.looping) {
+        button.classList.add('looping');
+      } else {
+        button.classList.remove('looping');
       }
     },
     togglePlay() {
@@ -456,6 +469,7 @@ export default defineComponent({
     this.button = this.$refs.playpause as HTMLSpanElement;
     this.button1 = this.$refs.playpause1 as HTMLSpanElement;
     this.setBtnIcon('play');
+    setIcon(this.$refs.loopButton, 'repeat');
 
     // add event listeners
     document.addEventListener('allpause', () => {  
@@ -464,6 +478,10 @@ export default defineComponent({
     document.addEventListener('allresume', () => {
       if (this.isCurrent())
         this.setBtnIcon('pause');
+    })
+    document.addEventListener('looptoggle', () => {
+      if (this.isCurrent())
+        this.toggleLooping();
     })
     document.addEventListener('addcomment', () => {
       if (this.isCurrent()) 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -3,6 +3,7 @@
     <div class="player-title">{{ displayTitle }}</div>
     <div class="horiz">
       <div v-show="!smallSize" class="vert">
+        <div class="playpause seconds" @click="skipToBeginning" ref="skipBackButton"></div>
         <div class="playpause" @click="togglePlay" ref="playpause"></div>
         <div class="playpause seconds" @click="toggleLooping" ref="loopButton"></div>
       </div>
@@ -266,6 +267,9 @@ export default defineComponent({
       const ev = new Event('allpause');
       document.dispatchEvent(ev);
     },
+    skipToBeginning() {
+      this.audio.currentTime = 0;
+    },
     timeUpdateHandler() {
       if (this.isCurrent()) {
         this.currentTime = this.audio?.currentTime;
@@ -470,6 +474,7 @@ export default defineComponent({
     this.button1 = this.$refs.playpause1 as HTMLSpanElement;
     this.setBtnIcon('play');
     setIcon(this.$refs.loopButton, 'repeat');
+    setIcon(this.$refs.skipBackButton, 'skip-back');
 
     // add event listeners
     document.addEventListener('allpause', () => {  

--- a/src/components/AudioComment.vue
+++ b/src/components/AudioComment.vue
@@ -1,12 +1,14 @@
 <template>
-  <div class="comment" @click="emitMovePlayhead">
-    <span class="timestamp">{{ cmt?.timeString }}</span>
-    <span class="content" v-html="cmt?.content"></span>
+  <div class="comment">
+    <span class="timestamp" @click="emitMovePlayhead">{{ cmt?.timeString }}</span>
+    <span class="content" v-html="cmt?.content" @click="emitMovePlayhead"></span>
+    <span class="loopcmt" ref="loopcmt" v-bind:class="{'looping': cmt?.looping}" @click="toggleLooping"></span>
   </div>
   
 </template>
 
 <script lang="ts">
+import { setIcon } from 'obsidian';
 import { AudioComment } from '../types';
 import { defineComponent, PropType } from 'vue';
 export default defineComponent({
@@ -20,8 +22,14 @@ export default defineComponent({
     },
     emitRemove() {
       this.$emit('remove', this.cmt.index);
-    }
+    },
+    toggleLooping() {
+      this.cmt.looping = ! this.cmt.looping;
+    },
   },
+  mounted() {
+    setIcon(this.$refs.loopcmt, 'repeat');
+  }
 })
 
 </script>

--- a/src/components/AudioComment.vue
+++ b/src/components/AudioComment.vue
@@ -2,7 +2,10 @@
   <div class="comment">
     <span class="timestamp" @click="emitMovePlayhead">{{ cmt?.timeString }}</span>
     <span class="content" v-html="cmt?.content" @click="emitMovePlayhead"></span>
-    <span class="loopcmt" ref="loopcmt" v-bind:class="{'looping': cmt?.looping}" @click="toggleLooping"></span>
+    <span class="loopcmt" ref="loopcmt"
+      v-bind:class="{'looping': cmt?.looping}"
+      @click="toggleLooping">
+    </span>
   </div>
   
 </template>
@@ -25,7 +28,7 @@ export default defineComponent({
     },
     toggleLooping() {
       this.cmt.looping = ! this.cmt.looping;
-    },
+    }
   },
   mounted() {
     setIcon(this.$refs.loopcmt, 'repeat');

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,6 +116,14 @@ export default class AudioPlayer extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: "audio-skip-back-beginning",
+			name: "Skip back to beginning",
+			callback: () => {
+				if (player.src) player.currentTime = 0;
+			}
+		});
+
 		this.registerMarkdownPostProcessor(
 			(
 				el: HTMLElement,

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,15 @@ export default class AudioPlayer extends Plugin {
 		});
 
 		this.addCommand({
+			id: "toggle-looping",
+			name: "Toggle looping of current track",
+			callback: () => {
+				const ev = new Event("looptoggle");
+				document.dispatchEvent(ev);
+			}
+		});
+
+		this.addCommand({
 			id: "add-audio-comment",
 			name: "Add bookmark",
 			callback: () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type AudioComment = {
 	index: number;
 	barEdges: [number, number];
 	overlapScore: number;
+	looping: boolean;
 };
 
 export type AudioPlayerRendererOptions = {

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,7 @@ If your plugin does not need CSS, delete this file.
 .playpause {
 	flex: 1;
 	margin: 6px;
+	margin-top: 1px;
 	background-color: var(--color-accent-1);
 	display: flex;
 	justify-content: center;
@@ -99,7 +100,7 @@ If your plugin does not need CSS, delete this file.
 	border-radius: 30px;
 	max-height: 40px;
 	max-width: 40px;
-	opacity: 0.8;
+	opacity: 0.7;
 	transition: all 0.15s;
 	cursor: pointer;
 }
@@ -109,13 +110,18 @@ If your plugin does not need CSS, delete this file.
 .playpause:active {
 	background-color: var(--color-base-10);
 }
+.playpause.looping {
+	opacity: 1;
+	color: var(--color-accent-1);
+}
 .seconds {
 	border-radius: 2;
 	min-height: unset;
 	padding-top: 0;
 	padding-bottom: 0;
-	height: 25px;
+	height: 15px;
 	flex: unset;
+	background: none;
 }
 .vert {
 	display: flex;
@@ -123,7 +129,7 @@ If your plugin does not need CSS, delete this file.
 }
 .vert:first-of-type {
 	margin-right: 6px;
-	margin-top: 12px;
+	margin-top: -5px;
 }
 .horiz {
 	display: flex;

--- a/styles.css
+++ b/styles.css
@@ -165,10 +165,9 @@ If your plugin does not need CSS, delete this file.
 	min-height: 20px;
 	transition: all 0.2s;
 	display: grid;
-	grid-template-columns: 80px 1fr;
+	grid-template-columns: 80px 1fr 20px;
 	gap: 15px;
 	padding-right: 1em;
-	cursor: pointer;
 	border-top: 1px solid transparent;
 }
 
@@ -181,6 +180,9 @@ If your plugin does not need CSS, delete this file.
 }
 .comment:active {
 	background-color: var(--color-base-10);
+}
+.comment > span:hover {
+	cursor: pointer;
 }
 
 .comment > .timestamp,
@@ -204,6 +206,22 @@ If your plugin does not need CSS, delete this file.
 }
 .delete-comment:active {
 	background-color: var(--color-base-10);
+}
+
+.comment > .loopcmt{
+	margin-top: 5px;
+}
+.comment > span ~ .loopcmt{
+	opacity: 0;
+}
+.comment:hover > .loopcmt{
+	opacity: 0.7;
+}
+.comment > .loopcmt:hover{
+	opacity: 1;
+}
+.loopcmt.looping {
+	color: var(--color-accent-1);
 }
 
 .comment-input {


### PR DESCRIPTION
Fixes #8 and https://github.com/noonesimg/obsidian-audio-player/issues/21

- Add a repeat 🔁 button on the audio player to toggle looping of the track
- On hover of each bookmark/comment, show the 🔁 button to toggle looping of the individual time segment
- Note: looping status (for whole track or segments) is not persisted after the note is closed in Obsidian