### PR TITLE
View and edit subtitle/lyrics files directly in Obsidian

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -124,6 +124,10 @@ export default class AudioPlayer extends Plugin {
 			}
 		});
 
+		// Treat subtitle/lyrics files as Markdown files that can be
+		// opened in the viewer and editor
+		this.registerExtensions(['lrc', 'srt', 'vtt'], 'markdown');
+
 		this.registerMarkdownPostProcessor(
 			(
 				el: HTMLElement,


### PR DESCRIPTION
Registers file extensions `.srt`/`.vtt` (subtitles) and `.lrc` (lyrics) for the Markdown viewType, such that these files can be opened in the Obsidian viewer/editor just like regular notes.

Follow-up to #7 as part of #6 .