### PR TITLE
For .lrc format comments, set end time as start time of next comment

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,8 +25,14 @@ export function hasOverlap(a: number[], b: number[]) {
 export function lrcToCommentList(el: HTMLElement, lrcText: string): HTMLElement {
 	const lrcItems = parseLrc(lrcText);
 	const list = el.createEl('ul');
-	lrcItems.forEach((l) => {
-		list.createEl('li', { text: `${l[0]} --- ${l[1]}` })
+	lrcItems.forEach((l, i) => {
+		// We assume that end time == start time of next lyric
+		let endTime = i < lrcItems.length - 1 ? lrcItems[i + 1][0] : '';
+		let sep = endTime ? '-' : ''
+		// Ignore entries with empty lyrics text
+		if (l[1]) {
+			list.createEl('li', { text: `${l[0]}${sep}${endTime} --- ${l[1]}` })
+		}
 	});
 	return list;
 }


### PR DESCRIPTION
This logic seems to be implied in the LRC standard itself, since blank lines (containing only timestamp) are used to delimit 'blocks' of lyrics or sung parts. We ignore (do not render as standalone comment) these blank lines and use them instead just as end time markers.