### PR TITLE
Timestamp links

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -469,6 +469,19 @@ export default defineComponent({
       if (this.audio.src === this.srcPath)
         this.setBtnIcon('play');
     });
+    this.$el.addEventListener('seek-to-timestamp', (event: CustomEvent) => {
+      if (this.getSectionInfo()) {
+        const { lineStart, lineEnd, timeInSeconds } = event.detail;
+        if (
+          timeInSeconds && timeInSeconds <= this.duration &&
+          (lineStart == null && lineEnd == null ||
+          lineStart == this.getSectionInfo().lineStart && lineEnd == this.getSectionInfo().lineEnd)
+        ) {
+          this.setPlayheadSecs(timeInSeconds);
+          localStorage.removeItem('musicPlayerSeek');
+        }
+      }
+    });
 
     this.$el.addEventListener('resize', () => {
       console.log(this.$el.clientWidth);
@@ -485,6 +498,22 @@ export default defineComponent({
 
     // Load comments
     setTimeout(() => { this.comments = this.getComments(); });
+
+    // Seek to timestamp based on cookie set after clicking a
+    // timestamp link (as alternative to handling seek event)
+    const seekToSeconds = localStorage.getItem('musicPlayerSeek');
+    if (seekToSeconds && this.getSectionInfo()) {
+      const [ lineStart, lineEnd, secondsStr ] = seekToSeconds.split(':');
+      const seconds = parseFloat(secondsStr);
+      if (
+        seconds && seconds <= this.duration &&
+        (lineStart == '' && lineEnd == '' ||
+        lineStart == this.getSectionInfo().lineStart && lineEnd == this.getSectionInfo().lineEnd)
+      ) {
+        this.setPlayheadSecs(seconds);
+        localStorage.removeItem('musicPlayerSeek');
+      }
+    }
 
     this.ro = new ResizeObserver(this.onResize);
     this.ro.observe(this.$el);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,3 +120,20 @@ export function parseSrt(srt: string): Array<Array<string>> {
     }
     return srtEntries;
 }
+
+export function parseTimestamp(timestamp: string): number {
+	const timestampPattern = /^(\d{1,2}:)?(\d{1,2}):(\d{2})$/;
+	// Split by colons and parse each part
+	const parts = timestamp.trim().split(':')
+		.map(part => parseFloat(part));
+	
+	let seconds = 0;
+	if (parts.length === 2) {
+		// MM:SS.000 format
+		seconds = parts[0] * 60 + parts[1];
+	} else if (parts.length === 3) {
+		// H:MM:SS.000 format
+		seconds = parts[0] * 3600 + parts[1] * 60 + parts[2];
+	}
+	return seconds;
+}


### PR DESCRIPTION
Internal links to audio player callout blocks that have a parseable timestamp as link text should trigger a timestamp seek in the linked player.